### PR TITLE
Fix long press not detected when on-press handler is absent

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,10 +8,6 @@ To use this library you can import the `modulino` module along with the desired 
 from modulino import ModulinoPixels
 
 pixels = ModulinoPixels()
-
-if not pixels.connected:
-    print("🤷 No pixel modulino found")    
-    exit()
 ```
 Once the desired object is obtained you can call functions and query properties on these objects such as `pixels.set_all_rgb(255, 0, 0)`.
 

--- a/examples/buttons.py
+++ b/examples/buttons.py
@@ -9,13 +9,8 @@ Initial author: Sebastian Romero (s.romero@arduino.cc)
 """
 
 from modulino import ModulinoButtons
-from sys import exit
 
 buttons = ModulinoButtons()
-
-if not buttons.connected:
-    print("🤷 No button modulino found")    
-    exit()
 
 buttons.on_button_a_press = lambda : print("Button A pressed")
 buttons.on_button_a_long_press = lambda : print("Button A long press")

--- a/examples/change_address.py
+++ b/examples/change_address.py
@@ -1,66 +1,47 @@
+"""
+This example shows how to change the I2C address of a Modulino device.
+After changing the address, the device will be reset and the new address will be verified.
+From then on, when creating a Modulino object, you should use the new address.
+e.g. ModulinoBuzzer(address=0x2A)
+
+Initial author: Sebastian Romero (s.romero@arduino.cc)
+"""
+
 from sys import exit
-from machine import I2C
 from time import sleep
-
-pinstrap_map = {
-    0x3C: "BUZZER",
-    0x7C: "BUTTONS",
-    0x76: "ENCODER",
-    0x74: "ENCODER",
-    0x6C: "SMARTLEDS"
-}
-
-def pinstrap_to_name(address):
-    if address in pinstrap_map:
-        return pinstrap_map[address]
-    return "UNKNOWN"
-
-bus = I2C(0)
-devices_on_bus = bus.scan()
+from modulino import Modulino
 
 print()
+devices = Modulino.available_devices()
 
-if len(devices_on_bus) == 0:
+if len(devices) == 0:
     print("No devices found on the bus. Try resetting the board.")
     exit(1)
 
 print("The following devices were found on the bus:")
 
-for index, device_address in enumerate(devices_on_bus):
-    pinstrap_address = bus.readfrom(device_address, 1)
-    device_name = pinstrap_to_name(pinstrap_address[0])
-    print(f"{index + 1}) {device_name} at {hex(device_address)}")
+for index, device in enumerate(devices):
+    print(f"{index + 1}) {device.device_type} at {hex(device.address)}")
 
 choice = int(input("\nEnter the device number for which you want to change the address: "))
-if choice < 1 or choice > len(devices_on_bus):
+
+if choice < 1 or choice > len(devices):
     print("Invalid choice. Please select a valid device number.")
     exit(1)
 
-selected_device_address = devices_on_bus[choice - 1]
-
-# Read address from user input
+selected_device = devices[choice - 1]
 new_address = int(input("Enter the new address (hexadecimal or decimal): "), 0)
 
 if new_address < 0 or new_address > 127:
     print("Invalid address. Address must be between 0 and 127")
     exit(1)
 
-print(f"Changing address of device at {hex(selected_device_address)} to {hex(new_address)}...")
-
-data = bytearray(40)
-# Set the first two bytes to 'C' and 'F' followed by the new address
-data[0:2] = b'CF'
-data[2] = new_address * 2
-
-try:
-  bus.writeto(selected_device_address, data)
-except OSError:
-  pass # Device resets immediately and causes ENODEV to be thrown which is expected
-sleep(1)
+print(f"Changing address of device at {hex(selected_device.address)} to {hex(new_address)}...")
+selected_device.change_address(new_address)
+sleep(1) # Give the device time to reset
 
 # Check if the address was successfully changed
-devices_on_bus = bus.scan()
-if new_address in devices_on_bus:
+if selected_device.connected:
     print(f"✅ Address changed successfully to {hex(new_address)}")
 else:
     print("❌ Failed to change address. Please try again.")

--- a/examples/change_address.py
+++ b/examples/change_address.py
@@ -1,0 +1,66 @@
+from sys import exit
+from machine import I2C
+from time import sleep
+
+pinstrap_map = {
+    0x3C: "BUZZER",
+    0x7C: "BUTTONS",
+    0x76: "ENCODER",
+    0x74: "ENCODER",
+    0x6C: "SMARTLEDS"
+}
+
+def pinstrap_to_name(address):
+    if address in pinstrap_map:
+        return pinstrap_map[address]
+    return "UNKNOWN"
+
+bus = I2C(0)
+devices_on_bus = bus.scan()
+
+print()
+
+if len(devices_on_bus) == 0:
+    print("No devices found on the bus. Try resetting the board.")
+    exit(1)
+
+print("The following devices were found on the bus:")
+
+for index, device_address in enumerate(devices_on_bus):
+    pinstrap_address = bus.readfrom(device_address, 1)
+    device_name = pinstrap_to_name(pinstrap_address[0])
+    print(f"{index + 1}) {device_name} at {hex(device_address)}")
+
+choice = int(input("\nEnter the device number for which you want to change the address: "))
+if choice < 1 or choice > len(devices_on_bus):
+    print("Invalid choice. Please select a valid device number.")
+    exit(1)
+
+selected_device_address = devices_on_bus[choice - 1]
+
+# Read address from user input
+new_address = int(input("Enter the new address (hexadecimal or decimal): "), 0)
+
+if new_address < 0 or new_address > 127:
+    print("Invalid address. Address must be between 0 and 127")
+    exit(1)
+
+print(f"Changing address of device at {hex(selected_device_address)} to {hex(new_address)}...")
+
+data = bytearray(40)
+# Set the first two bytes to 'C' and 'F' followed by the new address
+data[0:2] = b'CF'
+data[2] = new_address * 2
+
+try:
+  bus.writeto(selected_device_address, data)
+except OSError:
+  pass # Device resets immediately and causes ENODEV to be thrown which is expected
+sleep(1)
+
+# Check if the address was successfully changed
+devices_on_bus = bus.scan()
+if new_address in devices_on_bus:
+    print(f"✅ Address changed successfully to {hex(new_address)}")
+else:
+    print("❌ Failed to change address. Please try again.")

--- a/examples/pixels.py
+++ b/examples/pixels.py
@@ -10,13 +10,8 @@ Initial author: Sebastian Romero (s.romero@arduino.cc)
 
 from modulino import ModulinoPixels, ModulinoColor
 from time import sleep
-from sys import exit
 
 pixels = ModulinoPixels()
-
-if not pixels.connected:
-    print("🤷 No pixel modulino found")    
-    exit()
 
 for index in range(0, 8):
     color_wheel_colors = [

--- a/examples/thermo.py
+++ b/examples/thermo.py
@@ -8,13 +8,8 @@ Initial author: Sebastian Romero (s.romero@arduino.cc)
 
 from modulino import ModulinoThermo
 from time import sleep
-from sys import exit
 
 thermo_module = ModulinoThermo()
-
-if not thermo_module.connected:
-    print("🤷 No thermo modulino found")    
-    exit()
 
 while True:    
     temperature = thermo_module.temperature

--- a/src/modulino/buttons.py
+++ b/src/modulino/buttons.py
@@ -144,21 +144,24 @@ class ModulinoButtons(Modulino):
     # Check for press and release
     if(button_states_changed):
 
-      if(new_status[0] == 1 and previous_status[0] == 0 and self._on_button_a_press):
+      if(new_status[0] == 1 and previous_status[0] == 0):
         self._last_press_timestamps[0] = ticks_ms()
-        self._on_button_a_press()
+        if(self._on_button_a_press):
+          self._on_button_a_press()
       elif(new_status[0] == 0 and previous_status[0] == 1 and self._on_button_a_release):
         self._on_button_a_release()
       
-      if(new_status[1] == 1 and previous_status[1] == 0 and self._on_button_b_press):
+      if(new_status[1] == 1 and previous_status[1] == 0):
         self._last_press_timestamps[1] = ticks_ms()        
-        self._on_button_b_press()
+        if(self._on_button_b_press):
+          self._on_button_b_press()
       elif(new_status[1] == 0 and previous_status[1] == 1 and self._on_button_b_release):
         self._on_button_b_release()
       
-      if(new_status[2] == 1 and previous_status[2] == 0 and self._on_button_c_press):
+      if(new_status[2] == 1 and previous_status[2] == 0):
         self._last_press_timestamps[2] = ticks_ms()
-        self._on_button_c_press()
+        if(self._on_button_c_press):
+          self._on_button_c_press()
       elif(new_status[2] == 0 and previous_status[2] == 1 and self._on_button_c_release):
         self._on_button_c_release()
 


### PR DESCRIPTION
Fixes a bug that would cause the button long press not being detected when no on-press handler is registered.