### PR TITLE
Add Release Print in Knob Example

### DIFF
--- a/examples/knob.py
+++ b/examples/knob.py
@@ -22,7 +22,7 @@ knob.value = 5 # (Optional) Set an initial value
 knob.range = (-10, 10) # (Optional) Set a value range
 
 knob.on_press = lambda: print("🔘 Pressed!")
-knob.on_release = lambda: knob.reset()
+knob.on_release = lambda: (knob.reset(), print("🔘 Released!")) 
 knob.on_rotate_clockwise = lambda steps, value: print(f"🎛️ Rotated {steps} steps clockwise! Value: {value}")
 knob.on_rotate_counter_clockwise = lambda steps, value: print(f"🎛️ Rotated {steps} steps counter clockwise! Value: {value}")
 


### PR DESCRIPTION
A super small suggestion. I noticed that the knob example only prints when the knob is pressed but not when released. Maybe this adds too much noice to the cmmand line, but I thought I'd mention it :))