### PR TITLE
Remove lps22h dependency from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     ],
     "deps": [
       ["lsm6dsox", "latest"],
-      ["lps22h", "latest"],
       ["github:jposada202020/MicroPython_HS3003", "master"]
   ],
     "version": "1.0.0"


### PR DESCRIPTION
## Motivation
After this [commit](https://github.com/arduino/arduino-modulino-mpy/commit/85581b5639d05da825ecd2cccaecf70b9b00fb26#diff-ee8c70e5de315806718c7c48c22511627d5e80bb345c8e17379f0ea3840d9d46) (that removes the `pressure` modulino), the `lps22h` dependency can be removed because it is not used anymore.