### PR TITLE
Temporarily disable model ID check

### DIFF
--- a/.github/workflows/render-documentation.yml
+++ b/.github/workflows/render-documentation.yml
@@ -1,3 +1,6 @@
+# Alternative:
+# https://github.com/ml-tooling/lazydocs
+
 name: Render Documentation
 
 on:

--- a/src/modulino/lib/vl53l4cd.py
+++ b/src/modulino/lib/vl53l4cd.py
@@ -88,8 +88,8 @@ class VL53L4CD:
         self._i2c = i2c
         self._device_address = address
         model_id, module_type = self.model_info
-        if model_id != 0xEB or module_type != 0xAA:
-            raise RuntimeError(f"Wrong sensor ID ({model_id}) or type!")
+        # if model_id != 0xEB or module_type != 0xAA:
+        #     raise RuntimeError(f"Wrong sensor ID ({model_id}) or type!")
         self._ranging = False
         self._sensor_init()
 


### PR DESCRIPTION
This PR temporarily disables the model_id check to allow VL53L4ED to be used which reports 0xEC as the model ID. This sensor is populated on a small number of boards. On the majority of boards VL53L4CD is populated however which has 0xEA as model ID.